### PR TITLE
Add tests to ensure extension runs safely

### DIFF
--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -1,13 +1,17 @@
 --TEST--
-test1() Basic test
+phpinfo() shows evil info
 --EXTENSIONS--
 evil
 --FILE--
 <?php
-$ret = test1();
-
-var_dump($ret);
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+if (strpos($info, 'Eval') !== false && strpos($info, 'Disabled') !== false) {
+    echo 'info found';
+} else {
+    echo 'info missing';
+}
 ?>
 --EXPECT--
-The extension evil is loaded and working!
-NULL
+info found

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -1,12 +1,10 @@
 --TEST--
-test2() Basic test
+Eval disabled
 --EXTENSIONS--
 evil
 --FILE--
 <?php
-var_dump(test2());
-var_dump(test2('PHP'));
+eval('1+1;');
 ?>
---EXPECT--
-string(11) "Hello World"
-string(9) "Hello PHP"
+--EXPECTF--
+Fatal error: %s


### PR DESCRIPTION
## Summary
- revise tests to check module info
- add test ensuring eval() is disabled

## Testing
- `phpize` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_6846b7097e6c832ca713bd8dbc557795